### PR TITLE
Add ABI for MegaETH contract "zeROX"

### DIFF
--- a/abis.json
+++ b/abis.json
@@ -1,8 +1,77 @@
 {
-    "0x5337BCE2555943c69D5dE08f553Ecc4Ec4110102": {
-        "name": "Z℮ROX",
+    "0x5944674dDb33581c9c5c1CC57fC9a9B007A4d8AB": {
+        "name": "Megaeth",
         "abi": [
             {
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "initialMessage",
+				"type": "string"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "string",
+				"name": "oldMessage",
+				"type": "string"
+			},
+			{
+				"indexed": false,
+				"internalType": "string",
+				"name": "newMessage",
+				"type": "string"
+			}
+		],
+		"name": "MessageUpdated",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "newMessage",
+				"type": "string"
+			}
+		],
+		"name": "setMessage",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "getMessage",
+		"outputs": [
+			{
+				"internalType": "string",
+				"name": "",
+				"type": "string"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "owner",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]
     "inputs": [],
     "stateMutability": "nonpayable",
     "type": "constructor"


### PR DESCRIPTION
Hi, this PR adds the ABI for the "zeROX" contract deployed on MegaETH testnet.

Contract address: 0x5944674dDb33581c9c5c1CC57fC9a9B007A4d8AB

The ABI was copied directly from the compiler output in Remix IDE, with no modifications, to comply with the repository guidelines.

Thanks in advance for reviewing!